### PR TITLE
Fix crash on authentification error for a zone.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ _INSTALL_REQUIRES = [l for l in _REQUIREMENTS_TXT if "://" not in l]
 
 setuptools.setup(
     name='cloudflare-exporter',
-    version='0.1',
+    version='0.2',
     author='Criteo',
     url='https://github.com/criteo/cloudflare-exporter',
     author_email='github@criteo.com',


### PR DESCRIPTION
If an api token don't have access to a zone, analytics.colos raise a
CloudFlareAPIError.i
we just don't expose this zone now.