### PR TITLE
Add extended metrics ( from logs )

### DIFF
--- a/cloudflare_exporter/collector.py
+++ b/cloudflare_exporter/collector.py
@@ -1,10 +1,47 @@
+import time
+from collections import Counter, defaultdict
+from statistics import mean
+
 import CloudFlare
 from prometheus_client.core import GaugeMetricFamily
+
+from cloudflare_exporter.config import (LOGS_EXTENDED_METRIC,
+                                        LOGS_EXTENDED_METRIC_COUNT,
+                                        LOGS_EXTENDED_METRIC_SAMPLE,
+                                        LOGS_EXTENDED_METRIC_RANGE)
+from cloudflare_exporter.lib.statistics import quantiles
 
 
 class CloudflareCollector:
     def __init__(self, cloudflare_token):
         self.cloudflare_token = cloudflare_token
+
+    def logs_collect(self, families):
+        if LOGS_EXTENDED_METRIC:
+            families['received_requests_pop_origin'] = GaugeMetricFamily(
+                'cloudflare_by_origin_received_requests',
+                'Requests received at this PoP location.',
+                labels=['zone', 'colo_id', 'origin_ip', 'client_country'])
+
+            for tile in ['avg', '50tile', '90tile']:
+                families[f'origin_response_time_{tile}'] = GaugeMetricFamily(
+                    f'cloudflare_origin_response_time_{tile}',
+                    f'Response Time:{tile}',
+                    labels=['zone', 'colo_id', 'origin_ip', 'client_country'])
+
+            for metric in _get_cloudflare_metrics_from_logs(self.cloudflare_token):
+                for keys, value in metric.received_requests_pop_origin.items():
+                    families['received_requests_pop_origin'].add_metric(keys, value)
+                for keys, values in metric.origin_response_times.items():
+                    families['origin_response_time_avg'].add_metric(keys, mean(values))
+
+                    try:
+                        decile = quantiles(values, n=10)
+                    except ValueError:
+                        # Not enough Data.
+                        continue
+                    families['origin_response_time_50tile'].add_metric(keys, decile[5 - 1])
+                    families['origin_response_time_90tile'].add_metric(keys, decile[9 - 1])
 
     def collect(self):
         families = {
@@ -39,6 +76,9 @@ class CloudflareCollector:
                 labels=['zone', 'colo_id', 'threat_country'],
             ),
         }
+        if LOGS_EXTENDED_METRIC:
+            self.logs_collect(families)
+
         for zone, raw_data in _get_cloudflare_analytics(self.cloudflare_token):
             # We're interested in the latest metrics, however
             # the Cloudflare API doesn't guarantee non-zero values.
@@ -79,8 +119,8 @@ class CloudflareCollector:
                         [zone, pop_data['colo_id'], country], count
                     )
 
-                for metric in families.values():
-                    yield metric
+        for metric in families.values():
+            yield metric
 
 
 def _get_cloudflare_analytics(token):
@@ -95,3 +135,55 @@ def _get_cloudflare_analytics(token):
                 continue
             raise exception
         yield zone['name'], series
+
+
+def nanos2s(nanos):
+    """Transform nanoseconds to seconds
+
+    :param time: Time in Nanoseconds
+    :return: Time in seconds
+    """
+    return nanos / 1_000_000
+
+
+class LogMetrics:
+    def __init__(self):
+        self.received_requests_pop_origin = Counter()
+        self.origin_response_times = defaultdict(list)
+
+    def add(self, zone, serie):
+        # Log by originIP are useless in Cache Mode
+        if not serie['CacheTieredFill']:
+            key = (zone, serie['EdgeColoCode'], serie['OriginIP'], serie['ClientCountry'])
+            self.received_requests_pop_origin[key] += 1
+            self.origin_response_times[key].append(nanos2s(serie['OriginResponseTime']))
+
+
+def _get_cloudflare_metrics_from_logs(token):
+    cloudflare = CloudFlare.CloudFlare(debug=False, token=token)
+    # from cf docs: Must be at least 1 minute earlier than now and later than start
+    # Sometime 1 minutes is not enough...
+    end = int(time.time() - 60 * 1)
+    start = end - 60 * LOGS_EXTENDED_METRIC_RANGE
+    for zone in cloudflare.zones.get():
+        series = cloudflare.zones.logs.received(zone['id'],
+                                                params={'end': end,
+                                                        'start': start,
+                                                        'fields': 'CacheTieredFill,ClientCountry,'
+                                                                  'EdgeColoCode,ConnectTimestamp,'
+                                                                  'OriginIP,'
+                                                                  'OriginResponseTime',
+                                                        'count': LOGS_EXTENDED_METRIC_COUNT,
+                                                        'sample': LOGS_EXTENDED_METRIC_SAMPLE
+                                                        })
+        if not isinstance(series, list):
+            # cloudflare.zones.logs.received don't raise any error on authentification failure
+            # but answer {'success': False, 'errors': [{'code': 10000, 'message': 'Authentication error'}]}
+            if not series.get('errors') or series.get('errors')[0].get('code') != 10_000:
+                raise Exception(f'/zones.logs.received {series} - api call failed')
+            continue
+
+        metrics = LogMetrics()
+        for serie in series:
+            metrics.add(zone['name'], serie)
+    yield metrics

--- a/cloudflare_exporter/config.py
+++ b/cloudflare_exporter/config.py
@@ -1,3 +1,13 @@
 LOG_FORMAT = '%(asctime)s [%(levelname)s] %(funcName)s (%(filename)s:%(lineno)d) %(message)s'
 DEFAULT_HOST = '127.0.0.1'
 DEFAULT_PORT = 8080
+
+# To have extended stats, by origin IP, based on the logs.
+# https://developers.cloudflare.com/logs/logpull-api/requesting-logs/
+LOGS_EXTENDED_METRIC = True
+LOGS_EXTENDED_METRIC_COUNT = 10000
+LOGS_EXTENDED_METRIC_SAMPLE = 0.01
+
+# Time range in seconds for the logs
+# Adjust with you scrape_interval
+LOGS_EXTENDED_METRIC_RANGE = 1

--- a/cloudflare_exporter/lib/statistics.py
+++ b/cloudflare_exporter/lib/statistics.py
@@ -1,0 +1,40 @@
+# TODO: Use statistics.quantiles with python 3.8
+# From https://github.com/python/cpython/blob/3.8/Lib/statistics.py
+def quantiles(data, *, n=10, method='exclusive'):
+    """Divide *data* into *n* continuous intervals with equal probability.
+    Returns a list of (n - 1) cut points separating the intervals.
+    Set *n* to 4 for quartiles (the default).  Set *n* to 10 for deciles.
+    Set *n* to 100 for percentiles which gives the 99 cuts points that
+    separate *data* in to 100 equal sized groups.
+    The *data* can be any iterable containing sample.
+    The cut points are linearly interpolated between data points.
+    If *method* is set to *inclusive*, *data* is treated as population
+    data.  The minimum value is treated as the 0th percentile and the
+    maximum value is treated as the 100th percentile.
+    """
+    if n < 1:
+        raise ValueError('n must be at least 1')
+    data = sorted(data)
+    ld = len(data)
+    if ld < 2:
+        raise ValueError('must have at least two data points')
+    if method == 'inclusive':
+        m = ld - 1
+        result = []
+        for i in range(1, n):
+            j = i * m // n
+            delta = i * m - j * n
+            interpolated = (data[j] * (n - delta) + data[j + 1] * delta) / n
+            result.append(interpolated)
+        return result
+    if method == 'exclusive':
+        m = ld + 1
+        result = []
+        for i in range(1, n):
+            j = i * m // n  # rescale i to m/n
+            j = 1 if j < 1 else ld - 1 if j > ld - 1 else j  # clamp to 1 .. ld-1
+            delta = i * m - j * n  # exact integer math
+            interpolated = (data[j - 1] * (n - delta) + data[j] * delta) / n
+            result.append(interpolated)
+        return result
+    raise ValueError(f'Unknown method: {method!r}')

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ _INSTALL_REQUIRES = [l for l in _REQUIREMENTS_TXT if "://" not in l]
 
 setuptools.setup(
     name='cloudflare-exporter',
-    version='0.2',
+    version='0.3',
     author='Criteo',
     url='https://github.com/criteo/cloudflare-exporter',
     author_email='github@criteo.com',


### PR DESCRIPTION
- We cannot have metrics by OriginIP on the default metrics, we need
  to fetch logs ( last 5 minutes ) and create metrics from those.

  We have now metric for each Cloudflare-DC, to each Origin-IP
  We have the OriginResponseTime, and a count.